### PR TITLE
Updated CORS middleware config to include allow Access-Control-Allow-C…

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,10 @@ exports.start = function() {
   app.use(methodOverride());
 
   // enable CORS header
-  app.use(cors());
+  app.use(cors({
+    credentials: true,
+    origin: 'http://localhost:' + app.get('port')
+  }));
   // enable pre-flight for put/patch/delete
   app.options('*', cors());
 


### PR DESCRIPTION
Hi @basti1302 this should fix the issue you mentioned in https://github.com/basti1302/traverson/issues/48

Updated CORS middleware config to include allow Access-Control-Allow-Credentials and restrict allowed origin to localhost. Tested with latest Chrome and Firefox for MacOS.
